### PR TITLE
Fix logout 405 Method Not Allowed error

### DIFF
--- a/accounts/templates/accounts/home.html
+++ b/accounts/templates/accounts/home.html
@@ -90,6 +90,15 @@
             background-color: #1e7e34;
             transform: translateY(-1px);
         }
+        .logout-form {
+            display: inline;
+        }
+        .logout-form .btn {
+            border: none;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: inherit;
+        }
         .login-section {
             background: #f8f9fa;
             padding: 30px;
@@ -137,7 +146,10 @@
                 {% else %}
                     <a href="{% url 'admin:index' %}" class="btn btn-primary">Dashboard</a>
                 {% endif %}
-                <a href="{% url 'accounts:logout' %}" class="btn btn-secondary">Abmelden</a>
+                <form method="post" action="{% url 'accounts:logout' %}" class="logout-form">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-secondary">Abmelden</button>
+                </form>
             </div>
         {% else %}
             <div class="login-section">


### PR DESCRIPTION
## Summary
Fixes logout functionality that was failing with 405 Method Not Allowed error.

## Problem
The logout link was using a GET request (`<a href="{% url 'accounts:logout' %}">`), but Django's LogoutView only accepts POST requests for security reasons, causing:
```
"GET /accounts/logout/ HTTP/1.1" 405 0
```

## Solution  
- Changed logout link to use POST form with CSRF token
- Added CSS styling to maintain identical appearance
- Button styling matches existing design system
- Preserves security by using POST request with CSRF protection

## Changes
- Updated `accounts/templates/accounts/home.html`:
  - Added `.logout-form` CSS for inline form display
  - Replaced `<a href="">` with `<form method="post">` + `<button type="submit">`
  - Added `{% csrf_token %}` for security

## Test plan
- [x] Django system checks pass
- [x] Logout button appears identical to before
- [x] Logout now works without 405 error
- [x] CSRF protection is properly implemented

🤖 Generated with [Claude Code](https://claude.ai/code)